### PR TITLE
remove redundant check for index on token pair

### DIFF
--- a/scripts/indexer/set.js
+++ b/scripts/indexer/set.js
@@ -48,8 +48,8 @@ network.select('Set Intent to Trade', wallet => {
             if (balance.toNumber() < atomicAmount) {
               console.log(
                 chalk.red('\n\nError ') +
-                  `The selected account cannot stake ${values.stakeAmount} AST. Its balance is ${balance.toNumber() /
-                    10 ** constants.AST_DECIMALS}.\n`,
+                `The selected account cannot stake ${values.stakeAmount} AST. Its balance is ${balance.toNumber() /
+                10 ** constants.AST_DECIMALS}.\n`,
               )
             } else {
               new ethers.Contract(constants.stakingTokenAddresses[wallet.provider.network.chainId], IERC20.abi, wallet)
@@ -59,28 +59,19 @@ network.select('Set Intent to Trade', wallet => {
                     console.log(`\n${chalk.yellow('Error')}: Staking not Enabled`)
                     console.log(`Run the ${chalk.bold('yarn indexer:enable')} script to enable.\n`)
                   } else {
-                    new ethers.Contract(indexerAddress, Indexer.abi, wallet)
-                      .indexes(values.signerToken, values.senderToken, constants.PROTOCOL_CODE)
-                      .then(indexAddress => {
-                        if (indexAddress === constants.NULL_ADDRESS) {
-                          console.log(`\n${chalk.yellow('Error')}: Token Pair Not Found`)
-                          console.log(`Run the ${chalk.bold('yarn indexer:create')} script with your token pair.\n`)
-                        } else {
-                          prompt.confirm('Set an Intent', values, 'send transaction', () => {
-                            const locatorBytes = ethers.utils.formatBytes32String(values.locator)
-                            new ethers.Contract(indexerAddress, Indexer.abi, wallet)
-                              .setIntent(
-                                values.signerToken,
-                                values.senderToken,
-                                constants.PROTOCOL_CODE,
-                                atomicAmount,
-                                locatorBytes,
-                              )
-                              .then(prompt.handleTransaction)
-                              .catch(prompt.handleError)
-                          })
-                        }
-                      })
+                    prompt.confirm('Set an Intent', values, 'send transaction', () => {
+                      const locatorBytes = ethers.utils.formatBytes32String(values.locator)
+                      new ethers.Contract(indexerAddress, Indexer.abi, wallet)
+                        .setIntent(
+                          values.signerToken,
+                          values.senderToken,
+                          constants.PROTOCOL_CODE,
+                          atomicAmount,
+                          locatorBytes,
+                        )
+                        .then(prompt.handleTransaction)
+                        .catch(prompt.handleError)
+                    })
                   }
                 })
             }


### PR DESCRIPTION
The check for an existing index on the specified token pair exists earlier in this flow